### PR TITLE
decode and save base64'd gltf images

### DIFF
--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -1,4 +1,5 @@
 import argparse
+import base64
 import collections
 import json
 import logging
@@ -7,6 +8,8 @@ import numpy
 import os
 import re
 import shutil
+
+from io import BytesIO
 
 from gltf2loader import GLTF2Loader, PrimitiveMode, TextureWrap, MinFilter, MagFilter
 
@@ -290,12 +293,27 @@ class GLTF2USD:
 
         if 'images' in self.gltf_loader.json_data:
             self.images = []
-            for image in self.gltf_loader.json_data['images']:
-                image_path = os.path.join(self.gltf_loader.root_dir, image['uri'])
-                image_name = os.path.join(self.output_dir, ntpath.basename(image_path))
+            for i, image in enumerate(self.gltf_loader.json_data['images']):
+                image_name = ''
 
-                if self.gltf_loader.root_dir is not self.output_dir:
-                    shutil.copyfile(image_path, image_name)
+                # save data-uri textures
+                if image['uri'].startswith('data:image'):
+                    uri_data = image['uri'].split(',')[1]
+                    img = Image.open(BytesIO(base64.b64decode(uri_data)))
+
+                    # NOTE: image might not have a name
+                    image_name = image['name'] if 'name' in image else 'image{}.{}'.format(i, img.format)
+                    image_path = os.path.join(self.gltf_loader.root_dir, image_name)
+                    img.save(image_path)
+
+                # otherwise just copy the texture over
+                else:
+                    image_path = os.path.join(self.gltf_loader.root_dir, image['uri'])
+                    image_name = os.path.join(self.output_dir, ntpath.basename(image_path))
+
+                    if self.gltf_loader.root_dir is not self.output_dir:
+                        shutil.copyfile(image_path, image_name)
+
                 self.images.append(ntpath.basename(image_name))
 
     def _convert_materials_to_preview_surface(self):
@@ -461,7 +479,7 @@ class GLTF2USD:
                         primvar_st1_output=primvar_st1_output
                     )
 
-                
+
                 if pbr_metallic_roughness and 'baseColorTexture' in pbr_metallic_roughness:
                     base_color_factor = pbr_metallic_roughness['baseColorFactor'] if 'baseColorFactor' in pbr_metallic_roughness else (1,1,1,1)
                     fallback_base_color = (base_color_factor[0], base_color_factor[1], base_color_factor[2])
@@ -1091,14 +1109,15 @@ class GLTF2USD:
             raise Exception('Unsupported animation target path! {}'.format(target_path))
 
 
-    def unpack_textures_to_grayscale_images(self, image, color_components):
-        image_base_name = ntpath.basename(image)
+    def unpack_textures_to_grayscale_images(self, image_path, color_components):
+        # image_path may be a data uri?
+        image_base_name = ntpath.basename(image_path)
         texture_name = image_base_name
         for color_component, sdf_type in color_components.iteritems():
             if color_component == 'rgb':
                 pass
             else:
-                img = Image.open(image)
+                img = Image.open(image_path)
                 if img.mode == 'P':
                     img = img.convert('RGB')
                 if img.mode == 'RGB':
@@ -1170,7 +1189,7 @@ class GLTF2USD:
     '''
     def _convert_texture_to_usd(self, primvar_st0_output, primvar_st1_output, pbr_mat, gltf_texture, gltf_texture_name, color_components, scale_factor, fallback_factor, material_path, fallback_type, bias=None):
         image_name = gltf_texture if (isinstance(gltf_texture, basestring)) else self.images[gltf_texture['index']]
-        image_name = os.path.join(self.output_dir, image_name)
+        image_path = os.path.join(self.output_dir, image_name)
         texture_index = int(gltf_texture['index'])
         texture = self.gltf_loader.json_data['textures'][texture_index]
         wrap_modes = self._get_texture__wrap_modes(texture)
@@ -1182,7 +1201,7 @@ class GLTF2USD:
         if bias:
             texture_shader.CreateInput('bias', Sdf.ValueTypeNames.Float4).Set(bias)
 
-        texture_name = self.unpack_textures_to_grayscale_images(image_name, color_components)
+        texture_name = self.unpack_textures_to_grayscale_images(image_path, color_components)
         file_asset = texture_shader.CreateInput('file', Sdf.ValueTypeNames.Asset)
         file_asset.Set(texture_name)
 

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -1110,7 +1110,6 @@ class GLTF2USD:
 
 
     def unpack_textures_to_grayscale_images(self, image_path, color_components):
-        # image_path may be a data uri?
         image_base_name = ntpath.basename(image_path)
         texture_name = image_base_name
         for color_component, sdf_type in color_components.iteritems():


### PR DESCRIPTION
This diff decoded base64-encoded images, saves them, and makes them available to the rest of the USD conversion pipeline. 

closes #2 