### PR TITLE
decode all base64 data uri, regardless of mime-type

### DIFF
--- a/Source/gltf2loader.py
+++ b/Source/gltf2loader.py
@@ -1,8 +1,9 @@
 from enum import Enum
+import base64
 import json
 import os
+import re
 import struct
-import base64
 
 class AccessorType(Enum):
     SCALAR = 'SCALAR'
@@ -110,7 +111,7 @@ class GLTF2Loader:
         uri = buffer['uri']
         buffer_data = ''
 
-        if uri.startswith('data:application/octet-stream;base64,'):
+        if re.match(r'^data:.*?;base64,', uri):
             uri_data = uri.split(',')[1]
             buffer_data = base64.b64decode(uri_data)
             if 'byteOffset' in bufferview:


### PR DESCRIPTION
I found a model that used `data:application/gltf-buffer` [here], which should really be decoded as an octet-stream. There was also a [model] that curiously used `data:text/plain;base64`, though it was glTF 1.0. 

[here]: https://github.com/KhronosGroup/glTF-Sample-Models/blob/2eaf839717bba9ceb869dc1819af6e1bb98cfd3a/2.0/SimpleMorph/glTF-Embedded/SimpleMorph.gltf#L62
[model]: https://github.com/KhronosGroup/glTF-Sample-Models/blob/2eaf839717bba9ceb869dc1819af6e1bb98cfd3a/1.0/BoxWithoutIndices/glTF-Embedded/BoxWithoutIndices.gltf#L148