### PR TITLE
use resolved asset instead of usdc file to make usdz package

### DIFF
--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -1328,17 +1328,16 @@ def convert_to_usd(gltf_file, usd_file, fps, scale, arkit=False, verbose=False):
 
         if usd_file.endswith('.usdz'):
             r = Ar.GetResolver()
-            resolvedAsset = r.Resolve(usdc_file)
-            context = r.CreateDefaultContextForAsset(resolvedAsset)
+            resolved_asset = r.Resolve(usdc_file)
+            context = r.CreateDefaultContextForAsset(resolved_asset)
 
-            success = check_usd_compliance(resolvedAsset, arkit=args.arkit)
+            success = check_usd_compliance(resolved_asset, arkit=args.arkit)
             with Ar.ResolverContextBinder(context):
                 if arkit and not success:
                     print('USD is not ARKit compliant')
                     return
 
-                success = UsdUtils.CreateNewUsdzPackage(usdc_file, usd_file) and success
-
+                success = UsdUtils.CreateNewUsdzPackage(resolved_asset, usd_file) and success
                 if success:
                     usd.logger.info('created package {} with contents:'.format(usd_file))
                     zip_file = Usd.ZipFile.Open(usd_file)


### PR DESCRIPTION
Calling `CreateNewUsdzPackage` with the resolved asset instead of the usdc filename lets the function correctly set the usdc file as the first root file, stripping any relative paths. This also pulls in all of the assets that file references and adjusts their paths in the zipfile.