### PR TITLE
Fix opacity for base color factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@
 ## 0.1.3 (2018-10-26)
 **Fixed Bugs:**
 - Fixed strength
+
+## 0.1.4 (2018-10-28)
+**Fixed Bugs:**
+- Opacity for base color factor is now used even wihout base color texture

--- a/Source/_gltf2usd/usd_material.py
+++ b/Source/_gltf2usd/usd_material.py
@@ -226,12 +226,12 @@ class USDPreviewSurface():
     def _set_pbr_base_color(self, pbr_metallic_roughness):
         base_color_texture = pbr_metallic_roughness.get_base_color_texture()
         base_color_scale = pbr_metallic_roughness.get_base_color_factor()
+        self._opacity.Set(base_color_scale[3])
         if not base_color_texture:
             self._diffuse_color.Set(tuple(base_color_scale[0:3]))
-            self._opacity.Set(base_color_scale[3])
         else:
             destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGBA)
-            scale_factor = tuple([base_color_scale[0], base_color_scale[1], base_color_scale[2], base_color_scale[3]])
+            scale_factor = tuple(base_color_scale[0:3])
             usd_uv_texture = USDUVTexture("baseColorTexture", self._stage, self._usd_material._usd_material, base_color_texture, [self._st0, self._st1])
             usd_uv_texture._file_asset.Set(destination)
             usd_uv_texture._scale.Set(scale_factor)

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 3
+    _patch = 4
     @staticmethod
     def get_major_version_number():
         """Returns the major version


### PR DESCRIPTION
Mentioned in this issue: https://github.com/kcoley/gltf2usd/issues/88

## 0.1.4 (2018-10-28)
**Fixed Bugs:**
- Opacity for base color factor is now used even wihout base color texture