### PR TITLE
added alpha mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,12 @@
 ## 0.1.4 (2018-10-28)
 **Fixed Bugs:**
 - Opacity for base color factor is now used even wihout base color texture
+
+## 0.1.5 (2018-11-2)
+**Fixed Bugs:**
+- Fixed bug in using specular workflow (https://github.com/kcoley/gltf2usd/pull/92)
+
+**Changes:**
+- Added alpha mode to Material (https://github.com/kcoley/gltf2usd/issues/88)
+- If opacity is set in glTF, overwrite the alpha to 1 on USD export.  
+- Alpha mask is not supported in glTF so a warning is displayed and defaults to alpha blend

--- a/Source/_gltf2usd/gltf2/Material.py
+++ b/Source/_gltf2usd/gltf2/Material.py
@@ -5,6 +5,11 @@ class TextureWrap(Enum):
     MIRRORED_REPEAT = 33648
     REPEAT = 10497
 
+class AlphaMode(Enum):
+    BLEND = 'BLEND'
+    MASK = 'MASK'
+    OPAQUE = 'OPAQUE'
+
 class Texture(object):
     def __init__(self, texture_entry, gltf_loader):
         index = 0
@@ -106,8 +111,10 @@ class Material:
         self._name = material_entry['name'] if ('name' in material_entry) else 'material_{}'.format(material_index)
         self._index = material_index
         self._double_sided = material_entry['doubleSided'] if ('doubleSided' in material_entry) else False
-
+        
         self._pbr_metallic_roughness = PbrMetallicRoughness(material_entry['pbrMetallicRoughness'], gltf_loader) if ('pbrMetallicRoughness' in material_entry) else None
+
+        self._alpha_mode = material_entry['alphaMode'] if ('alphaMode' in material_entry) else AlphaMode.OPAQUE
 
         self._normal_texture = NormalTexture(material_entry['normalTexture'], gltf_loader) if ('normalTexture' in material_entry) else None
         self._emissive_factor = material_entry['emissiveFactor'] if ('emissiveFactor' in material_entry) else [0,0,0]
@@ -120,6 +127,10 @@ class Material:
 
     def is_double_sided(self):
         return self._double_sided
+
+    @property
+    def alpha_mode(self):
+        return self._alpha_mode
 
     def get_index(self):
         return self._index

--- a/Source/_gltf2usd/usd_material.py
+++ b/Source/_gltf2usd/usd_material.py
@@ -3,6 +3,7 @@ from enum import Enum
 from pxr import Gf, Sdf, UsdGeom, UsdShade
 
 from gltf2 import Material, GLTFImage
+from gltf2.Material import AlphaMode
 from gltf2loader import TextureWrap
 
 class USDMaterial():
@@ -156,7 +157,7 @@ class USDPreviewSurface():
     def _set_pbr_metallic_roughness(self, gltf_material):
         pbr_metallic_roughness = gltf_material.get_pbr_metallic_roughness()
         if (pbr_metallic_roughness):
-            self._set_pbr_base_color(pbr_metallic_roughness)
+            self._set_pbr_base_color(pbr_metallic_roughness, gltf_material.alpha_mode)
             self._set_pbr_metallic(pbr_metallic_roughness)
             self._set_pbr_roughness(pbr_metallic_roughness)
 
@@ -223,15 +224,24 @@ class USDPreviewSurface():
 
             
 
-    def _set_pbr_base_color(self, pbr_metallic_roughness):
+    def _set_pbr_base_color(self, pbr_metallic_roughness, alpha_mode):
         base_color_texture = pbr_metallic_roughness.get_base_color_texture()
         base_color_scale = pbr_metallic_roughness.get_base_color_factor()
-        self._opacity.Set(base_color_scale[3])
+        if AlphaMode(alpha_mode) != AlphaMode.OPAQUE:
+            if AlphaMode(alpha_mode) == AlphaMode.MASK:
+                print('Alpha Mask not supported in USDPreviewSurface!  Using Alpha Blend...')
+
+            self._opacity.Set(base_color_scale[3])
+
         if not base_color_texture:
             self._diffuse_color.Set(tuple(base_color_scale[0:3]))
         else:
-            destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGBA)
-            scale_factor = tuple(base_color_scale[0:4])
+            if AlphaMode(alpha_mode) == AlphaMode.OPAQUE:
+                destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGB)
+                scale_factor = (base_color_scale[0], base_color_scale[1], base_color_scale[2], 1.0)
+            else:
+                destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGBA)
+                scale_factor = tuple(base_color_scale[0:4])
             usd_uv_texture = USDUVTexture("baseColorTexture", self._stage, self._usd_material._usd_material, base_color_texture, [self._st0, self._st1])
             usd_uv_texture._file_asset.Set(destination)
             usd_uv_texture._scale.Set(scale_factor)

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 4
+    _patch = 5
     @staticmethod
     def get_major_version_number():
         """Returns the major version


### PR DESCRIPTION
## 0.1.5 (2018-11-2)
**Fixed Bugs:**
- Fixed bug in using specular workflow (https://github.com/kcoley/gltf2usd/pull/92)

**Changes:**
- Added alpha mode to Material (https://github.com/kcoley/gltf2usd/issues/88)
- If opacity is set in glTF, overwrite the alpha to 1 on USD export.  
- Alpha mask is not supported in glTF so a warning is displayed and defaults to alpha blend