### PR TITLE
When using alpha opaque, the base color texture is cloned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,7 @@
 ## 0.1.6 (2018-11-3)
 **Fixed Bugs:**
 - Fixed bug in joint names to allow support for animations for iOS (https://github.com/kcoley/gltf2usd/issues/79)
+
+## 0.1.7 (2018-11-6)
+**Changes:**
+- When using alpha opaque, the base color texture is cloned

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -46,6 +46,10 @@ class GLTFImage(object):
             img = img.convert('RGBA')
         img_channels = img.split()
         if channels == ImageColorChannels.RGB:
+            if img.mode == "RGBA": #Make a copy and add opaque 
+                file_name = '{0}_{1}'.format('RGB', file_name)
+                destination = os.path.join(output_dir, file_name)
+
             img = Image.merge('RGB', (img_channels[0], img_channels[1], img_channels[2]))
         elif channels == ImageColorChannels.RGBA:
             img = original_img.convert('RGBA')

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 6
+    _patch = 7
     @staticmethod
     def get_major_version_number():
         """Returns the major version


### PR DESCRIPTION
## 0.1.7 (2018-11-6)
**Changes:**
- When using alpha opaque, the base color texture is cloned