### PR TITLE
normal texture change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,7 @@
 ## 0.1.7 (2018-11-6)
 **Changes:**
 - When using alpha opaque, the base color texture is cloned
+
+## 0.1.8 (2018-11-8)
+**Changes:**
+- If a normal texture has only one channel, the channel is applied to RGB as a new texture

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -45,6 +45,9 @@ class GLTFImage(object):
         if img.mode == 'P':
             img = img.convert('RGBA')
         img_channels = img.split()
+        if len(img_channels) == 1: #distribute grayscale image across rgb
+            img = Image.merge('RGB', (img_channels[0], img_channels[0], img_channels[0]))
+            img_channels = img.split()
         if channels == ImageColorChannels.RGB:
             if img.mode == "RGBA": #Make a copy and add opaque 
                 file_name = '{0}_{1}'.format('RGB', file_name)

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 7
+    _patch = 8
     @staticmethod
     def get_major_version_number():
         """Returns the major version


### PR DESCRIPTION
## 0.1.8 (2018-11-8)
**Changes:**
- If a normal texture has only one channel, the channel is applied to RGB as a new texture