### PR TITLE
handle vector4 vertex color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,4 @@
 ## 0.1.11 (2018-12-4)
 **Changes:**
 - Set vertex colors for Color4 (vertex color alpha currently not supported)
+- Resolves (https://github.com/kcoley/gltf2usd/issues/113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,7 @@
 ## 0.1.10 (2018-11-12)
 **Changes:**
 - Added optimize-textures flag to help reduce texture size when generating usdz files
+
+## 0.1.11 (2018-12-4)
+**Changes:**
+- Set vertex colors for Color4 (vertex color alpha currently not supported)

--- a/Source/_gltf2usd/gltf2/Mesh.py
+++ b/Source/_gltf2usd/gltf2/Mesh.py
@@ -10,14 +10,20 @@ class PrimitiveModeType(Enum):
     TRIANGLE_FAN = 6
 
 class PrimitiveAttribute:
-    def __init__(self, attribute_name, attribute_data, min_value=None, max_value=None):
+    def __init__(self, attribute_name, attribute_data, accessor_type, min_value=None, max_value=None):
         self._attribute_type = attribute_name
         self._attribute_data = attribute_data
+        self._accessor_type = accessor_type
         self._min_value = min_value
         self._max_value = max_value
 
-    def get_type(self):
+    @property
+    def attribute_type(self):
         return self._attribute_type
+
+    @property
+    def accessor_type(self):
+        return self._accessor_type
 
     def get_min_value(self):
         return self._min_value
@@ -62,7 +68,7 @@ class Primitive:
                 min_value = accessor['min'] if ('min' in accessor) else None
                 max_value = accessor['max'] if ('max' in accessor) else None
 
-                self._attributes[attribute_name] = PrimitiveAttribute(attribute_name, data, min_value, max_value)
+                self._attributes[attribute_name] = PrimitiveAttribute(attribute_name, data, accessor['type'], min_value, max_value)
 
         self._indices = self._get_indices(primitive_entry, gltf_loader)
         self._mode = PrimitiveModeType(primitive_entry['mode']) if ('mode' in primitive_entry) else PrimitiveModeType.TRIANGLES

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 10
+    _patch = 11
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -310,7 +310,13 @@ class GLTF2USD(object):
 
             if attribute_name == 'COLOR_0':
                 prim_var = UsdGeom.PrimvarsAPI(mesh)
-                colors = prim_var.CreatePrimvar('displayColor', Sdf.ValueTypeNames.Color3f, 'vertex').Set(attribute.get_data())
+                print(attribute.accessor_type)
+                data = attribute.get_data()
+                if attribute.accessor_type == 'VEC4':
+                    print('Vertex color alpha currently not supported.  Defaulting to vertex color without alpha.')
+                    data = [Gf.Vec3f(entry[0:3]) for entry in attribute.get_data()]
+
+                colors = prim_var.CreatePrimvar('displayColor', Sdf.ValueTypeNames.Color3f, 'vertex').Set(data)
 
             if attribute_name == 'TEXCOORD_0':
                 data = attribute.get_data()


### PR DESCRIPTION
## 0.1.11 (2018-12-4)
**Changes:**
- Set vertex colors for Color4 (vertex color alpha currently not supported)
- Resolves (https://github.com/kcoley/gltf2usd/issues/113)