### PR TITLE
fix for texture transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,8 @@
 - Fixed a bug where multiple embedded textures within the same buffer were not extracted properly
 **Changes:**
 - Resolves (https://github.com/kcoley/gltf2usd/issues/125)
+
+## 0.1.15 (2019-01-11)
+**Fixed Bugs:**
+- Fix for throwing when USD minor version is 19 and path version is 1 [spiderworm](https://github.com/kcoley/gltf2usd/pull/130)
+- Fixed bug where texture transform generation would fail on index out of range (https://github.com/kcoley/gltf2usd/issues/131)

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -170,8 +170,8 @@ class GLTFImage(object):
             for row in range(new_img.size[1]):
                 res = np.matmul(texture_transform_matrix, np.array([col/float(img.width),row/float(img.height),1]))
 
-                c = int(round(_normalized_texcoord(res[0,0]) * height))
-                r = int(round(_normalized_texcoord(res[0,1]) * width))
+                c = min(int(round(_normalized_texcoord(res[0,0]) * height)), img.height - 1)
+                r = min(int(round(_normalized_texcoord(res[0,1]) * width)), img.width - 1)
                 pixel = source_image_pixels[r * width + c]
                 pixels[col, row] = pixel
 

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 14
+    _patch = 15
     @staticmethod
     def get_major_version_number():
         """Returns the major version


### PR DESCRIPTION
## 0.1.15 (2019-01-11)
**Fixed Bugs:**
- Fix for throwing when USD minor version is 19 and path version is 1 [spiderworm](https://github.com/kcoley/gltf2usd/pull/130)
- Fixed bug where texture transform generation would fail on index out of range (https://github.com/kcoley/gltf2usd/issues/131)