### PR TITLE
preserve material name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,3 +94,7 @@
 ## 0.1.16 (2019-01-17)
 **Changes:**
 - Add option to toggle texture transform texture generation (enable `--generate_texture_transform_texture`, disable `--no-generate_texture_transform_texture`) (https://github.com/kcoley/gltf2usd/issues/133)
+
+## 0.1.17 (2019-01-24)
+**Changes:**
+- Preserve material names of gltf if present (https://github.com/kcoley/gltf2usd/issues/135)

--- a/Source/_gltf2usd/usd_material.py
+++ b/Source/_gltf2usd/usd_material.py
@@ -7,8 +7,7 @@ from gltf2.Material import AlphaMode
 from gltf2loader import TextureWrap
 
 class USDMaterial():
-    def __init__(self, stage, material_scope, index, gltf2loader):
-        name = 'pbrmaterial_{}'.format(index)
+    def __init__(self, stage, name, material_scope, index, gltf2loader):
         self._gltf2loader = gltf2loader
         self._stage = stage
         self._material_scope = material_scope
@@ -36,7 +35,7 @@ class USDPreviewSurface():
         self._usd_material = usd_material
         self._output_directory = output_directory
         material_path = usd_material._usd_material.GetPath()
-        material = UsdShade.Shader.Define(self._stage, material_path.AppendChild('pbrMat'))
+        material = UsdShade.Shader.Define(self._stage, material_path.AppendChild(gltf_material.get_name()))
         material.CreateIdAttr('UsdPreviewSurface')
         self._initialize_material(material, self)
         self._initialize_from_gltf_material(gltf_material)

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 16
+    _patch = 17
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -449,7 +449,7 @@ class GLTF2USD(object):
         scope = UsdGeom.Scope.Define(self.stage, material_path_root)
 
         for i, material in enumerate(self.gltf_loader.get_materials()):
-            usd_material = USDMaterial(self.stage, scope, i, self.gltf_loader)
+            usd_material = USDMaterial(self.stage, material.get_name(), scope, i, self.gltf_loader)
             usd_material.convert_material_to_usd_preview_surface(material, self.output_dir)
             self.usd_materials.append(usd_material)
 


### PR DESCRIPTION
## 0.1.17 (2019-01-24)
**Changes:**
- Preserve material names of gltf if present (https://github.com/kcoley/gltf2usd/issues/135)