### PR TITLE
cache accessor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,8 @@
 ## 0.1.17 (2019-01-24)
 **Changes:**
 - Preserve material names of gltf if present (https://github.com/kcoley/gltf2usd/issues/135)
+
+## 0.1.18 (2019-01-28)
+**Changes:**
+- Cache accessor data to help with glTF import optimization (https://github.com/kcoley/gltf2usd/issues/137)
+- Adding logging for exporting mesh primitive data, behind the -v flag

--- a/Source/_gltf2usd/gltf2/Animation.py
+++ b/Source/_gltf2usd/gltf2/Animation.py
@@ -45,14 +45,14 @@ class AnimationSampler:
     def get_input_data(self):
         if not self._input_data:
             accessor = self._animation._gltf_loader.json_data['accessors'][self._input_accessor_index]
-            self._input_data = self._animation._gltf_loader.get_data(accessor)
+            self._input_data = self._animation._gltf_loader.get_data(accessor, self._input_accessor_index)
         
         return self._input_data
 
     def get_output_data(self):
         if not self._output_data:
             accessor = self._animation._gltf_loader.json_data['accessors'][self._output_accessor_index]
-            self._output_data = self._animation._gltf_loader.get_data(accessor)
+            self._output_data = self._animation._gltf_loader.get_data(accessor, self._output_accessor_index)
         
         return self._output_data
         

--- a/Source/_gltf2usd/gltf2/Mesh.py
+++ b/Source/_gltf2usd/gltf2/Mesh.py
@@ -43,7 +43,7 @@ class PrimitiveTarget:
             accessor = gltf_loader.json_data['accessors'][target_entry[entry]]
             if self._name == None:
                 self._name = accessor['name'] if ('name' in accessor) else 'shape_{}'.format(target_index)
-            data = gltf_loader.get_data(accessor)
+            data = gltf_loader.get_data(accessor, target_entry[entry])
             self._attributes[entry] = data
 
     def get_attributes(self):
@@ -64,11 +64,12 @@ class Primitive:
             for attribute_name in primitive_entry['attributes']:
                 accessor_index = primitive_entry['attributes'][attribute_name]
                 accessor = gltf_loader.json_data['accessors'][accessor_index]
-                data = gltf_loader.get_data(accessor)
-                min_value = accessor['min'] if ('min' in accessor) else None
-                max_value = accessor['max'] if ('max' in accessor) else None
+                data = gltf_loader.get_data(accessor, accessor_index)
+                if data:
+                    min_value = accessor['min'] if ('min' in accessor) else None
+                    max_value = accessor['max'] if ('max' in accessor) else None
 
-                self._attributes[attribute_name] = PrimitiveAttribute(attribute_name, data, accessor['type'], min_value, max_value)
+                    self._attributes[attribute_name] = PrimitiveAttribute(attribute_name, data, accessor['type'], min_value, max_value)
 
         self._indices = self._get_indices(primitive_entry, gltf_loader)
         self._mode = PrimitiveModeType(primitive_entry['mode']) if ('mode' in primitive_entry) else PrimitiveModeType.TRIANGLES
@@ -85,7 +86,7 @@ class Primitive:
         if 'indices' in primitive_entry:
             accessor_index = primitive_entry['indices']
             accessor = gltf_loader.json_data['accessors'][accessor_index]
-            data = gltf_loader.get_data(accessor)
+            data = gltf_loader.get_data(accessor, accessor_index)
             return data
 
         else:
@@ -112,6 +113,7 @@ class Primitive:
 
 class Mesh:
     def __init__(self, mesh_entry, mesh_index, gltf_loader):
+        self._name = mesh_entry['name'] if 'name' in mesh_entry else 'mesh_{}'.format(mesh_index)
         self._primitives = []
         self._weights = []
         self._index = mesh_index
@@ -121,6 +123,10 @@ class Mesh:
             for i, primitive_entry in enumerate(mesh_entry['primitives']):
                 primitive = Primitive(primitive_entry, i, self, gltf_loader)
                 self._primitives.append(primitive)
+
+    @property
+    def name(self):
+        return self._name
 
     def get_weights(self):
         return self._weights

--- a/Source/_gltf2usd/gltf2/Skin.py
+++ b/Source/_gltf2usd/gltf2/Skin.py
@@ -11,7 +11,7 @@ class Skin:
     def _init_inverse_bind_matrices(self, gltf2_loader, skin_entry):
         inverse_bind_matrices = []
         if 'inverseBindMatrices' in skin_entry:
-            inverse_bind_matrices = gltf2_loader.get_data(accessor=gltf2_loader.json_data['accessors'][skin_entry['inverseBindMatrices']])
+            inverse_bind_matrices = gltf2_loader.get_data(accessor=gltf2_loader.json_data['accessors'][skin_entry['inverseBindMatrices']], accessor_index=skin_entry['inverseBindMatrices'])
         
         return inverse_bind_matrices
 

--- a/Source/_gltf2usd/gltf2loader.py
+++ b/Source/_gltf2usd/gltf2loader.py
@@ -104,6 +104,7 @@ class GLTF2Loader:
         if not gltf_file.endswith('.gltf'):
             raise Exception('Can only accept .gltf files')
 
+        self._accessor_data_map = {}
         self.root_dir = os.path.dirname(gltf_file)
         self._optimize_textures = optimize_textures
         self._generate_texture_transform_texture = generate_texture_transform_texture
@@ -237,7 +238,10 @@ class GLTF2Loader:
         remainder = value % size
         return value if (remainder == 0) else (value + size - remainder)
 
-    def get_data(self, accessor):
+    def get_data(self, accessor, accessor_index):
+        if accessor_index in self._accessor_data_map.keys():
+            return self._accessor_data_map[accessor_index]
+
         bufferview = self.json_data['bufferViews'][accessor['bufferView']]
         buffer = self.json_data['buffers'][bufferview['buffer']]
         accessor_type = AccessorType(accessor['type'])
@@ -299,4 +303,5 @@ class GLTF2Loader:
                 data_arr.append(entries[0])
             offset = offset + bytestride
 
+        self._accessor_data_map[accessor_index] = data_arr
         return data_arr

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 17
+    _patch = 18
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -263,8 +263,14 @@ class GLTF2USD(object):
             node_index {int} -- glTF node index
         """
         #for each mesh primitive, create a USD mesh
+        primitive_count = 1
+        max_primitive_count = len(gltf_mesh.get_primitives())
         for primitive in gltf_mesh.get_primitives():
             self._convert_primitive_to_mesh(primitive, usd_node, gltf_node, gltf_mesh)
+            if self.verbose:
+                self.logger.debug('mesh {0}: primitive {1}/{2}'.format(gltf_mesh.name, primitive_count, max_primitive_count))
+
+            primitive_count += 1
 
     def _convert_primitive_to_mesh(self, gltf_primitive, usd_node, gltf_node, gltf_mesh):
         """


### PR DESCRIPTION
## 0.1.18 (2019-01-28)
**Changes:**
- Cache accessor data to help with glTF import optimization (https://github.com/kcoley/gltf2usd/issues/137)
- Adding logging for exporting mesh primitive data, behind the -v flag