### PR TITLE
support TEXCOORD_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,7 @@
 ## 0.1.22 (2019-02-15)
 **Fixed Bugs:**
 - Resolve some issues with materials containing special characters by appending index to name (https://github.com/kcoley/gltf2usd/issues/147)
+
+## 0.1.23 (2019-02-27)
+**Fixed Bugs:**
+- Fixed a bug where `TEXCOORD_1` attribute was not being read (https://github.com/kcoley/gltf2usd/issues/149)

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 22
+    _patch = 23
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -332,6 +332,17 @@ class GLTF2USD(object):
                 prim_var = UsdGeom.PrimvarsAPI(mesh)
                 uv = prim_var.CreatePrimvar('primvars:st0', Sdf.ValueTypeNames.TexCoord2fArray, 'vertex')
                 uv.Set(invert_uvs)
+
+            if attribute_name == 'TEXCOORD_1':
+                data = attribute.get_data()
+                invert_uvs = []
+                for uv in data:
+                    new_uv = (uv[0], 1 - uv[1])
+                    invert_uvs.append(new_uv)
+                prim_var = UsdGeom.PrimvarsAPI(mesh)
+                uv = prim_var.CreatePrimvar('primvars:st1', Sdf.ValueTypeNames.TexCoord2fArray, 'vertex')
+                uv.Set(invert_uvs)
+                
             if attribute_name == 'JOINTS_0':
                 self._convert_skin_to_usd(gltf_node, gltf_primitive, parent_node, mesh)
         


### PR DESCRIPTION
## 0.1.23 (2019-02-27)
**Fixed Bugs:**
- Fixed a bug where `TEXCOORD_1` attribute was not being read (https://github.com/kcoley/gltf2usd/issues/149)