### PR TITLE
Fix blend shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@
 **Fixed Bugs:**
 - Fixed a bug where `TEXCOORD_1` attribute was not being read (https://github.com/kcoley/gltf2usd/issues/149)
 
-## 0.1.24 (2019-02-27)
+## 0.2.0 (2019-02-27)
 **Fixed Bugs:**
 - Fix blend shapes
 **Changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,10 @@
 ## 0.1.23 (2019-02-27)
 **Fixed Bugs:**
 - Fixed a bug where `TEXCOORD_1` attribute was not being read (https://github.com/kcoley/gltf2usd/issues/149)
+
+## 0.1.24 (2019-02-27)
+**Fixed Bugs:**
+- Fix blend shapes
+**Changes:**
+- The Usd file generation now happens in a temp directory
+- Add `--scale-texture` optional parameter to multiply metallic/roughness factors by textures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,4 @@
 - Added creator metadata
 - Moved material scope to below root xform
 - connect opacity of diffuse texture if alpha blend or mask is used
+- Export extras data on nodes and glTF asset 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,5 @@
 **Changes:**
 - The Usd file generation now happens in a temp directory
 - Add `--scale-texture` optional parameter to multiply metallic/roughness factors by textures
+- Added creator metadata
+- Moved material scope to below root xform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,4 @@
 - Add `--scale-texture` optional parameter to multiply metallic/roughness factors by textures
 - Added creator metadata
 - Moved material scope to below root xform
+- connect opacity of diffuse texture if alpha blend or mask is used

--- a/Source/_gltf2usd/gltf2/Animation.py
+++ b/Source/_gltf2usd/gltf2/Animation.py
@@ -4,7 +4,7 @@ from _gltf2usd.gltf2usdUtils import GLTF2USDUtils
 
 from pxr import Gf
 
-class AnimationSampler:
+class AnimationSampler(object):
     def __init__(self, sampler_entry, animation):
         self._animation = animation
         self._input_accessor_index = sampler_entry['input']
@@ -117,7 +117,7 @@ class AnimationSampler:
             
  
 
-class AnimationChannelTarget:
+class AnimationChannelTarget(object):
     def __init__(self, animation_channel_target_entry):
         self._node_index = animation_channel_target_entry['node']
         self._path = animation_channel_target_entry['path']
@@ -125,7 +125,7 @@ class AnimationChannelTarget:
     def path(self):
         return self._path
 
-class AnimationChannel:
+class AnimationChannel(object):
     def __init__(self, channel_entry, animation):
         self._sampler_index = channel_entry['sampler']
         self._target = AnimationChannelTarget(channel_entry['target'])
@@ -143,7 +143,7 @@ class AnimationChannel:
         return self._animation._samplers[self._sampler_index]
 
 
-class Animation:
+class Animation(object):
     def __init__(self, animation_entry, index, gltf_loader):
         self._gltf_loader = gltf_loader
         self._name = animation_entry['name'] if ('name' in animation_entry) else 'animation_{}'.format(index)

--- a/Source/_gltf2usd/gltf2/Asset.py
+++ b/Source/_gltf2usd/gltf2/Asset.py
@@ -1,0 +1,28 @@
+class Asset(object):
+    def __init__(self, asset_entry):
+        self._generator = asset_entry['generator'] if 'generator' in asset_entry else None
+        self._version = asset_entry['version'] if 'version' in asset_entry else None
+        self._extras = asset_entry['extras'] if 'extras' in asset_entry else {}
+        self._copyright = asset_entry['copyright'] if 'copyright' in asset_entry else None
+        self._minversion = asset_entry['minversion'] if 'minversion' in asset_entry else None
+
+    @property
+    def generator(self):
+        return self._generator
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def minversion(self):
+        return self._minversion
+
+    @property
+    def copyright(self):
+        return self._copyright
+
+    @property
+    def extras(self):
+        return self._extras
+

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -58,7 +58,7 @@ class GLTFImage(object):
         return self._image_path
 
 
-    def write_to_directory(self, output_dir, channels, texture_prefix, offset = [0,0], scale = [1,1], rotation = 0):
+    def write_to_directory(self, output_dir, channels, texture_prefix, offset = [0,0], scale = [1,1], rotation = 0, scale_factor=None):
         file_name = '{0}_{1}'.format(texture_prefix, ntpath.basename(self._name)) if texture_prefix else ntpath.basename(self._name)
         destination = os.path.join(output_dir, file_name)
         original_img = Image.open(self._image_path)
@@ -87,6 +87,19 @@ class GLTFImage(object):
         if destination.endswith('jpg') or destination.endswith('.jpeg'):
             img = img.convert('RGB')
 
+        if scale_factor:
+            width, height = img.size
+            for x in range(width):
+                for y in range(height):
+                    value = img.getpixel((x, y))
+                    if isinstance(value, int):
+                        value = value * scale_factor[0]
+                    else:
+                        value[0] = value[0] * scale_factor[0]
+                        value[1] = value[1] * scale_factor[1]
+                        value[2] = value[2] * scale_factor[2]
+
+                    img.putpixel((x, y), (int(value)))
         #apply texture transform if necessary
         if offset != [0,0] or scale != [1,1] or rotation != 0:
             if not self._generate_texture_transform_texture:

--- a/Source/_gltf2usd/gltf2/GLTFImage.py
+++ b/Source/_gltf2usd/gltf2/GLTFImage.py
@@ -94,12 +94,15 @@ class GLTFImage(object):
                     value = img.getpixel((x, y))
                     if isinstance(value, int):
                         value = value * scale_factor[0]
+                        img.putpixel((x, y), (int(value)))
                     else:
-                        value[0] = value[0] * scale_factor[0]
-                        value[1] = value[1] * scale_factor[1]
-                        value[2] = value[2] * scale_factor[2]
-
-                    img.putpixel((x, y), (int(value)))
+                        value = list(value)
+                        value[0] = int(value[0] * scale_factor[0])
+                        value[1] = int(value[1] * scale_factor[1])
+                        value[2] = int(value[2] * scale_factor[2])
+                        value = tuple(value)
+                        img.putpixel((x, y), (value))
+                    
         #apply texture transform if necessary
         if offset != [0,0] or scale != [1,1] or rotation != 0:
             if not self._generate_texture_transform_texture:

--- a/Source/_gltf2usd/gltf2/Material.py
+++ b/Source/_gltf2usd/gltf2/Material.py
@@ -43,8 +43,8 @@ class Texture(object):
     def get_wrap_t(self):
         return self._wrap_t
 
-    def write_to_directory(self, output_directory, channels, texture_prefix=""):
-        return self._image.write_to_directory(output_directory, channels, texture_prefix, self._tt_offset, self._tt_scale, self._tt_rotation)
+    def write_to_directory(self, output_directory, channels, texture_prefix="", scale_factor=None):
+        return self._image.write_to_directory(output_directory, channels, texture_prefix, self._tt_offset, self._tt_scale, self._tt_rotation, scale_factor)
 
     def get_texcoord_index(self):
         return self._texcoord_index
@@ -72,7 +72,7 @@ class OcclusionTexture(Texture):
     def strength(self):
         return self._strength
 
-class PbrMetallicRoughness:
+class PbrMetallicRoughness(object):
     def __init__(self, pbr_metallic_roughness_entry, gltf_loader):
         self._name = pbr_metallic_roughness_entry['name'] if ('name' in pbr_metallic_roughness_entry) else 'pbr_mat_roughness_texture'
         self._base_color_factor = pbr_metallic_roughness_entry['baseColorFactor'] if ('baseColorFactor' in pbr_metallic_roughness_entry) else [1.0,1.0,1.0, 1.0]

--- a/Source/_gltf2usd/gltf2/Mesh.py
+++ b/Source/_gltf2usd/gltf2/Mesh.py
@@ -9,7 +9,7 @@ class PrimitiveModeType(Enum):
     TRIANGLE_STRIP = 5
     TRIANGLE_FAN = 6
 
-class PrimitiveAttribute:
+class PrimitiveAttribute(object):
     def __init__(self, attribute_name, attribute_data, accessor_type, min_value=None, max_value=None):
         self._attribute_type = attribute_name
         self._attribute_data = attribute_data
@@ -35,7 +35,7 @@ class PrimitiveAttribute:
         return self._attribute_data
 
 
-class PrimitiveTarget:
+class PrimitiveTarget(object):
     def __init__(self, target_entry, target_index, gltf_loader):
         self._name = None
         self._attributes = {}
@@ -53,7 +53,7 @@ class PrimitiveTarget:
         return self._name
 
 
-class Primitive:
+class Primitive(object):
     def __init__(self, primitive_entry, i, gltf_mesh, gltf_loader):
         self._name = primitive_entry['name'] if ('name' in primitive_entry) else 'primitive_{}'.format(i)
         self._attributes = {}
@@ -111,7 +111,7 @@ class Primitive:
 
 
 
-class Mesh:
+class Mesh(object):
     def __init__(self, mesh_entry, mesh_index, gltf_loader):
         self._name = mesh_entry['name'] if 'name' in mesh_entry else 'mesh_{}'.format(mesh_index)
         self._primitives = []

--- a/Source/_gltf2usd/gltf2/Node.py
+++ b/Source/_gltf2usd/gltf2/Node.py
@@ -24,6 +24,7 @@ class Node(object):
         
         self._children_indices = node_dict['children'] if ('children' in node_dict) else []
         self._children = []
+        self._extras = node_dict['extras'] if 'extras' in node_dict else {}
 
     @property
     def name(self):
@@ -64,3 +65,7 @@ class Node(object):
     @property
     def index(self):
         return self._node_index
+
+    @property
+    def extras(self):
+        return self._extras

--- a/Source/_gltf2usd/gltf2/Node.py
+++ b/Source/_gltf2usd/gltf2/Node.py
@@ -1,6 +1,6 @@
 import unicodedata
 
-class Node:
+class Node(object):
     """Create a glTF node object
     """
 

--- a/Source/_gltf2usd/gltf2/Scene.py
+++ b/Source/_gltf2usd/gltf2/Scene.py
@@ -1,4 +1,4 @@
-class Scene:
+class Scene(object):
     def __init__(self, scene_entry, scene_index, nodes):
         self._nodes = []
         if 'nodes' in scene_entry:

--- a/Source/_gltf2usd/gltf2/Skin.py
+++ b/Source/_gltf2usd/gltf2/Skin.py
@@ -1,5 +1,5 @@
 from sets import Set
-class Skin:
+class Skin(object):
     """Represents a glTF Skin
     """
 

--- a/Source/_gltf2usd/gltf2loader.py
+++ b/Source/_gltf2usd/gltf2loader.py
@@ -8,7 +8,7 @@ import struct
 
 import gltf2usdUtils
 
-from gltf2 import Skin, Node, Animation, Scene, Mesh, Material, GLTFImage
+from gltf2 import Skin, Node, Animation, Scene, Mesh, Material, GLTFImage, Asset
 
 
 class AccessorType(Enum):
@@ -119,6 +119,7 @@ class GLTF2Loader(object):
     def _initialize(self):
         """Initializes the glTF loader
         """
+        self._initialize_asset()
         self._initialize_images()
         self._initialize_materials()
         self._initialize_meshes()
@@ -127,6 +128,12 @@ class GLTF2Loader(object):
         self._initialize_scenes()
         
         self._initialize_animations()
+
+    def _initialize_asset(self):
+        if 'asset' in self.json_data:
+            self._asset = Asset.Asset(self.json_data['asset'])
+        else:
+            self._asset = None
 
     def _initialize_images(self):
         self._images = []
@@ -222,6 +229,10 @@ class GLTF2Loader(object):
             for node in self.nodes:
                 if node._skin_index != None:
                     node._skin = self.skins[node._skin_index]
+
+
+    def get_asset(self):
+        return self._asset
 
     def get_nodes(self):
         return self.nodes

--- a/Source/_gltf2usd/gltf2loader.py
+++ b/Source/_gltf2usd/gltf2loader.py
@@ -11,7 +11,6 @@ import gltf2usdUtils
 from gltf2 import Skin, Node, Animation, Scene, Mesh, Material, GLTFImage
 
 
-
 class AccessorType(Enum):
     SCALAR = 'SCALAR'
     VEC2 = 'VEC2'
@@ -88,7 +87,7 @@ def accessor_component_type_bytesize(x):
 
 
 
-class GLTF2Loader:
+class GLTF2Loader(object):
     """A very simple glTF loader.  It is essentially a utility to load data from accessors
     """
 

--- a/Source/_gltf2usd/gltf2usdUtils.py
+++ b/Source/_gltf2usd/gltf2usdUtils.py
@@ -2,7 +2,7 @@ import re
 
 from pxr import Gf, UsdSkel
 
-class GLTF2USDUtils:
+class GLTF2USDUtils(object):
     @staticmethod
     def convert_to_usd_friendly_node_name(name):
         """Format a glTF name to make it more USD friendly

--- a/Source/_gltf2usd/gltfUsdMaterialHelper.py
+++ b/Source/_gltf2usd/gltfUsdMaterialHelper.py
@@ -1,3 +1,3 @@
-class GLTFUSDMaterialHelper:
+class GLTFUSDMaterialHelper(object):
     def __init__(self):
         pass

--- a/Source/_gltf2usd/usd_material.py
+++ b/Source/_gltf2usd/usd_material.py
@@ -12,7 +12,7 @@ class USDMaterial(object):
         self._gltf2loader = gltf2loader
         self._stage = stage
         self._material_scope = material_scope
-        self._material_path = Sdf.Path('{0}/{1}'.format('/Materials', name))
+        self._material_path = Sdf.Path('{0}/{1}'.format('/root/Materials', name))
         self._usd_material = UsdShade.Material.Define(stage, self._material_path)
         
         self._usd_material_surface_output = self._usd_material.CreateOutput("surface", Sdf.ValueTypeNames.Token)

--- a/Source/_gltf2usd/usd_material.py
+++ b/Source/_gltf2usd/usd_material.py
@@ -7,8 +7,8 @@ from _gltf2usd.gltf2usdUtils import GLTF2USDUtils
 from gltf2.Material import AlphaMode
 from gltf2loader import TextureWrap
 
-class USDMaterial():
-    def __init__(self, stage, name, material_scope, index, gltf2loader):
+class USDMaterial(object):
+    def __init__(self, stage, name, material_scope, index, gltf2loader, scale_texture=False):
         self._gltf2loader = gltf2loader
         self._stage = stage
         self._material_scope = material_scope
@@ -17,9 +17,10 @@ class USDMaterial():
         
         self._usd_material_surface_output = self._usd_material.CreateOutput("surface", Sdf.ValueTypeNames.Token)
         self._usd_material_displacement_output = self._usd_material.CreateOutput("displacement", Sdf.ValueTypeNames.Token)
+        self._scale_texture = scale_texture
 
     def convert_material_to_usd_preview_surface(self, gltf_material, output_directory, material_name):
-        usd_preview_surface = USDPreviewSurface(self._stage, gltf_material, self, output_directory, material_name)
+        usd_preview_surface = USDPreviewSurface(self._stage, gltf_material, self, output_directory, material_name, self._scale_texture)
         usd_preview_surface._name = material_name
 
     def get_usd_material(self):
@@ -28,11 +29,12 @@ class USDMaterial():
 
 
 
-class USDPreviewSurface():
+class USDPreviewSurface(object):
     """Models a physically based surface for USD
     """
-    def __init__(self, stage, gltf_material, usd_material, output_directory, material_name):
+    def __init__(self, stage, gltf_material, usd_material, output_directory, material_name, scale_texture=False):
         self._stage = stage
+        self._scale_texture = scale_texture
         self._usd_material = usd_material
         self._output_directory = output_directory
         material_path = usd_material._usd_material.GetPath()
@@ -40,9 +42,6 @@ class USDPreviewSurface():
         material.CreateIdAttr('UsdPreviewSurface')
         self._initialize_material(material, self)
         self._initialize_from_gltf_material(gltf_material)
-
-        self._stage = stage
-
 
     def _initialize_material(self, material, usd_preview_surface_material):
         shader = material
@@ -56,17 +55,12 @@ class USDPreviewSurface():
         self._displacement_output = shader.CreateOutput('displacement', Sdf.ValueTypeNames.Token)
         self._usd_material._usd_material_displacement_output.ConnectToSource(self._displacement_output)
         
-
-        self._diffuse_color = (1.0, 1.0, 1.0)
-        self._emissive_color = (0.0, 0.0, 0.0)
         self._specular_color = material.CreateInput('specularColor', Sdf.ValueTypeNames.Color3f)
         self._specular_color.Set((1.0,1.0,1.0))
         
         self._metallic = material.CreateInput('metallic', Sdf.ValueTypeNames.Float)
-        self._metallic.Set(1.0)
 
         self._roughness = material.CreateInput('roughness', Sdf.ValueTypeNames.Float)
-        self._roughness.Set(1.0)
 
         self._clearcoat = material.CreateInput('clearcoat', Sdf.ValueTypeNames.Float)
         self._clearcoat.Set(0.0)
@@ -75,7 +69,6 @@ class USDPreviewSurface():
         self._clearcoat_roughness.Set(0.01)
 
         self._opacity = material.CreateInput('opacity', Sdf.ValueTypeNames.Float)
-        self._opacity.Set(1.0)
 
         self._ior = material.CreateInput('ior', Sdf.ValueTypeNames.Float)
         self._ior.Set(1.5)
@@ -86,17 +79,13 @@ class USDPreviewSurface():
         self._displacement.Set(0.0)
 
         self._occlusion = material.CreateInput('occlusion', Sdf.ValueTypeNames.Float)
-        self._occlusion.Set(1.0)
 
         self._emissive_color = material.CreateInput('emissiveColor', Sdf.ValueTypeNames.Color3f)
-        self._emissive_color.Set((0, 0, 0))
 
         self._diffuse_color = material.CreateInput('diffuseColor', Sdf.ValueTypeNames.Color3f)
-        self._diffuse_color.Set((1, 1, 1))
 
         self._st0 = USDPrimvarReaderFloat2(self._stage, self._usd_material._material_path, 'st0')
         self._st1 = USDPrimvarReaderFloat2(self._stage, self._usd_material._material_path, 'st1')
-
 
     def _initialize_from_gltf_material(self, gltf_material):
         self._set_normal_texture(gltf_material)
@@ -104,8 +93,6 @@ class USDPreviewSurface():
         self._set_occlusion_texture(gltf_material)
         self._set_khr_material_pbr_specular_glossiness(gltf_material)
         
-        
-
     def _set_normal_texture(self, gltf_material):
         normal_texture = gltf_material.get_normal_texture()
         if (not normal_texture):
@@ -186,7 +173,9 @@ class USDPreviewSurface():
             usd_uv_texture._fallback.Set(scale_factor)
             texture_shader = usd_uv_texture.get_shader()
             texture_shader.CreateOutput('rgb', Sdf.ValueTypeNames.Float3)
+            texture_shader.CreateOutput('a', Sdf.ValueTypeNames.Float)
             self._diffuse_color.ConnectToSource(texture_shader, 'rgb')
+            self._opacity.ConnectToSource(texture_shader, 'a')
 
     def _set_pbr_specular_glossiness_specular(self, pbr_specular_glossiness):
         specular_glossiness_texture = pbr_specular_glossiness.get_specular_glossiness_texture()
@@ -195,8 +184,9 @@ class USDPreviewSurface():
         if not specular_glossiness_texture:
             self._specular_color.Set(specular_factor)
         else:
+            scale_factor = (specular_factor[0], specular_factor[1], specular_factor[2], 1)
             destination = specular_glossiness_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGB, "specular")
-            scale_factor = (specular_factor[0], specular_factor[1], specular_factor[2], 1) 
+
             usd_uv_texture = USDUVTexture("specularTexture", self._stage, self._usd_material._usd_material, specular_glossiness_texture, [self._st0, self._st1])
             usd_uv_texture._file_asset.Set(destination)
             usd_uv_texture._scale.Set(scale_factor)
@@ -238,7 +228,7 @@ class USDPreviewSurface():
         else:
             if AlphaMode(alpha_mode) == AlphaMode.OPAQUE:
                 destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGB)
-                scale_factor = (base_color_scale[0], base_color_scale[1], base_color_scale[2], 1.0)
+                scale_factor = (base_color_scale[0], base_color_scale[1], base_color_scale[2], base_color_scale[3])
             else:
                 destination = base_color_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.RGBA)
                 scale_factor = tuple(base_color_scale[0:4])
@@ -248,19 +238,27 @@ class USDPreviewSurface():
             usd_uv_texture._fallback.Set(scale_factor)
             texture_shader = usd_uv_texture.get_shader()
             texture_shader.CreateOutput('rgb', Sdf.ValueTypeNames.Float3)
+            texture_shader.CreateOutput('a', Sdf.ValueTypeNames.Float)
             self._diffuse_color.ConnectToSource(texture_shader, 'rgb')
+            self._opacity.ConnectToSource(texture_shader, 'a')
 
     def _set_pbr_metallic(self, pbr_metallic_roughness):
         metallic_roughness_texture = pbr_metallic_roughness.get_metallic_roughness_texture()
         metallic_factor = pbr_metallic_roughness.get_metallic_factor()
-        if not metallic_roughness_texture:
+        if not metallic_roughness_texture or metallic_factor == 0:
             self._metallic.Set(metallic_factor)
         else:
-            destination = metallic_roughness_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.B, "metallic")
+            scale_texture = None
             scale_factor = tuple([metallic_factor]*4)
             usd_uv_texture = USDUVTexture("metallicTexture", self._stage, self._usd_material._usd_material, metallic_roughness_texture, [self._st0, self._st1])
+            if self._scale_texture:
+                scale_texture = scale_factor
+                usd_uv_texture._scale.Set(tuple([1.0]*4))
+            else:
+                usd_uv_texture._scale.Set(scale_factor)
+            destination = metallic_roughness_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.B, "metallic", scale_texture)
+            
             usd_uv_texture._file_asset.Set(destination)
-            usd_uv_texture._scale.Set(scale_factor)
             usd_uv_texture._fallback.Set(scale_factor)
             texture_shader = usd_uv_texture.get_shader()
             texture_shader.CreateOutput('r', Sdf.ValueTypeNames.Float)
@@ -269,25 +267,24 @@ class USDPreviewSurface():
     def _set_pbr_roughness(self, pbr_metallic_roughness):
         metallic_roughness_texture = pbr_metallic_roughness.get_metallic_roughness_texture()
         roughness_factor = pbr_metallic_roughness.get_roughness_factor()
-        if not metallic_roughness_texture:
+        if not metallic_roughness_texture or roughness_factor == 0:
             self._roughness.Set(roughness_factor)
         else:
-            destination = metallic_roughness_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.G, "roughness")
+            scale_texture = None
             scale_factor = tuple([roughness_factor]*4)
             usd_uv_texture = USDUVTexture("roughnessTexture", self._stage, self._usd_material._usd_material, metallic_roughness_texture, [self._st0, self._st1])
+            if self._scale_texture:
+                scale_texture = scale_factor
+                usd_uv_texture._scale.Set(tuple([1.0]*4))
+            else:
+                usd_uv_texture._scale.Set(scale_factor)
+
+            destination = metallic_roughness_texture.write_to_directory(self._output_directory, GLTFImage.ImageColorChannels.G, "roughness", scale_texture)
             usd_uv_texture._file_asset.Set(destination)
-            usd_uv_texture._scale.Set(scale_factor)
             usd_uv_texture._fallback.Set(scale_factor)
             texture_shader = usd_uv_texture.get_shader()
             texture_shader.CreateOutput('r', Sdf.ValueTypeNames.Float)
             self._roughness.ConnectToSource(texture_shader, 'r')
-
-
-
-
-
-        
-
 
     def export_to_stage(self, usd_material):
         """Converts a glTF material to a usd preview surface
@@ -304,7 +301,7 @@ class USDPreviewSurface():
         usd_material._usd_material_displacement_output.ConnectToSource(displacement_output)
 
 
-class USDPrimvarReaderFloat2():
+class USDPrimvarReaderFloat2(object):
     def __init__(self, stage, material_path, var_name):
         primvar = UsdShade.Shader.Define(stage, material_path.AppendChild('primvar_{}'.format(var_name)))
         primvar.CreateIdAttr('UsdPrimvarReader_float2')

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -3,7 +3,7 @@ class Version(object):
     """
     _major = 0
     _minor = 1
-    _patch = 23
+    _patch = 24
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/_gltf2usd/version.py
+++ b/Source/_gltf2usd/version.py
@@ -2,8 +2,8 @@ class Version(object):
     """Version API for gltf2usd
     """
     _major = 0
-    _minor = 1
-    _patch = 24
+    _minor = 2
+    _patch = 0
     @staticmethod
     def get_major_version_number():
         """Returns the major version

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -466,7 +466,7 @@ class GLTF2USD(object):
         Converts the glTF materials to preview surfaces
         """
         self.usd_materials = []
-        material_path_root = '/Materials'
+        material_path_root = '/root/Materials'
         scope = UsdGeom.Scope.Define(self.stage, material_path_root)
         material_name_map = []
 
@@ -830,6 +830,7 @@ def convert_to_usd(gltf_file, usd_file, fps, scale, arkit=False, verbose=False, 
         usd = GLTF2USD(gltf_file=gltf_file, usd_file=temp_usd_file, fps=fps, scale=scale, verbose=verbose, use_euler_rotation=use_euler_rotation, optimize_textures=optimize_textures, generate_texture_transform_texture=generate_texture_transform_texture, scale_texture=scale_texture)
         if usd.stage:
             asset = usd.stage.GetRootLayer()
+            asset.customLayerData = {'creator': 'gltf2usd v{}'.format(__version__)}
             usd.logger.info('Conversion complete!')
 
             asset.Save()

--- a/Source/gltf2usd.py
+++ b/Source/gltf2usd.py
@@ -9,6 +9,7 @@ import logging
 import ntpath
 import numpy
 import os
+import tempfile
 import re
 import shutil
 from io import BytesIO
@@ -37,7 +38,7 @@ class GLTF2USD(object):
         TextureWrap.REPEAT: 'repeat',
     }
 
-    def __init__(self, gltf_file, usd_file, fps, scale, verbose=False, use_euler_rotation=False, optimize_textures=False, generate_texture_transform_texture=True):
+    def __init__(self, gltf_file, usd_file, fps, scale, verbose=False, use_euler_rotation=False, optimize_textures=False, generate_texture_transform_texture=True, scale_texture=False):
         """Initializes the glTF to USD converter
 
         Arguments:
@@ -56,6 +57,7 @@ class GLTF2USD(object):
         self.verbose = verbose
         self.scale = scale
         self.use_euler_rotation = use_euler_rotation
+        self._scale_texture = scale_texture
 
         self.output_dir = os.path.dirname(os.path.abspath(usd_file))
         if self.verbose:
@@ -345,7 +347,7 @@ class GLTF2USD(object):
                 
             if attribute_name == 'JOINTS_0':
                 self._convert_skin_to_usd(gltf_node, gltf_primitive, parent_node, mesh)
-        
+
         weights = gltf_mesh.get_weights()
         if targets:
             skinBinding = UsdSkel.BindingAPI.Apply(mesh.GetPrim())
@@ -357,6 +359,8 @@ class GLTF2USD(object):
 
             # link the skeleton animation to skelAnim
             skinBinding.CreateAnimationSourceRel().AddTarget(skelAnim.GetPath())
+            skeleton_skel_binding = UsdSkel.BindingAPI(skeleton)
+            skeleton_skel_binding.CreateAnimationSourceRel().AddTarget(skelAnim.GetPath())
 
             # link the skeleton to skeleton
             skinBinding.CreateSkeletonRel().AddTarget(skeleton.GetPath())
@@ -369,10 +373,10 @@ class GLTF2USD(object):
                 names.append(blend_shape_name)
 
             skelAnim.CreateBlendShapesAttr().Set(names)
+            self._set_blendshape_weights(skelAnim, usd_node, gltf_node)
             skinBinding.CreateBlendShapesAttr(names)
 
             # Set the starting weights of each blendshape to the weights defined in the glTF primitive
-            skelAnim.CreateBlendShapeWeightsAttr().Set(weights)
             blend_shape_targets = skinBinding.CreateBlendShapeTargetsRel()
 
             # Define offsets for each blendshape, and add them as skel:blendShapes and skel:blendShapeTargets
@@ -479,7 +483,7 @@ class GLTF2USD(object):
                 material_name = new_material_name
 
             material_name_map.append(material_name)
-            usd_material = USDMaterial(self.stage, material_name, scope, i, self.gltf_loader)
+            usd_material = USDMaterial(self.stage, material_name, scope, i, self.gltf_loader, self._scale_texture)
             usd_material.convert_material_to_usd_preview_surface(material, self.output_dir, material_name)
             self.usd_materials.append(usd_material)
 
@@ -534,6 +538,8 @@ class GLTF2USD(object):
                 rotation = animation_channel.sampler.get_interpolated_output_data(input_sample) 
             elif animation_channel.target.path == 'scale':
                 scale = animation_channel.sampler.get_interpolated_output_data(input_sample) 
+            elif animation_channel.target.path == 'weights':
+                weights = animation_channel.sampler.get_output_data()
 
         return UsdSkel.MakeTransform(translation, rotation, scale)
 
@@ -567,6 +573,8 @@ class GLTF2USD(object):
             skel_binding_api.CreateSkeletonRel().AddTarget(skeleton.GetPath())
             if skeleton_animation:
                 skel_binding_api.CreateAnimationSourceRel().AddTarget(skeleton_animation.GetPath())
+                skeleton_skel_binding_api = UsdSkel.BindingAPI(skeleton)
+                skeleton_skel_binding_api.CreateAnimationSourceRel().AddTarget(skeleton_animation.GetPath())
             
             bind_matrices = self._compute_bind_transforms(gltf_skin)
 
@@ -695,7 +703,6 @@ class GLTF2USD(object):
         Returns:
             [type] -- [description]
         """
-
         max_time = -999
         min_time = 999
         for channel in animation_channels:
@@ -704,13 +711,32 @@ class GLTF2USD(object):
 
 
         transform = usd_node.AddTransformOp(opSuffix='transform')
-
-        for i, keyframe in enumerate(numpy.arange(min_time, max_time, 1./self.fps)):
-            transform_node = self._create_keyframe_transform_node(gltf_node, animation_channels, keyframe)
-            transform.Set(transform_node, Usd.TimeCode(i))
+        for animation_channel in animation_channels:
+            #if animation_channel.target.path != 'weights':
+            for i, keyframe in enumerate(numpy.arange(min_time, max_time, 1./self.fps)):
+                transform_node = self._create_keyframe_transform_node(gltf_node, animation_channels, keyframe)
+                transform.Set(transform_node, Usd.TimeCode(i))
 
         MinMaxTime = collections.namedtuple('MinMaxTime', ('max', 'min'))
         return MinMaxTime(max=max_time, min=min_time)
+
+    def _set_blendshape_weights(self, skel_anim, usd_node, gltf_node):
+        animations = self.gltf_loader.get_animations()
+        if (len(animations) > 0): # only support first animation group
+            animation = animations[0]
+
+            animation_channels = animation.get_animation_channels_for_node(gltf_node)
+            for animation_channel in animation_channels:
+                if animation_channel.target.path == 'weights':
+                    output_data = animation_channel.sampler.get_output_data()
+                    input_data = animation_channel.sampler.get_input_data()
+                    
+                    output_data_entries = []
+                    for index in range(0, len(output_data)/2):
+                        output_data_entries.append([output_data[index * 2], output_data[index * 2 + 1]])
+                    usd_blend_shape_weights = skel_anim.CreateBlendShapeWeightsAttr()
+                    for entry in zip(output_data_entries, input_data):
+                        usd_blend_shape_weights.Set(Vt.FloatArray(entry[0]), Usd.TimeCode(entry[1] * self.fps))
 
     def _get_keyframe_conversion_func(self, usd_node, animation_channel):
         """Convert glTF key frames to USD animation key frames
@@ -725,7 +751,6 @@ class GLTF2USD(object):
         Returns:
             [func] -- USD animation conversion function
         """
-
         path = animation_channel.target.path
         animation_sampler = animation_channel.sampler
 
@@ -789,7 +814,7 @@ def check_usd_compliance(rootLayer, arkit=False):
     return len(errors) == 0 and len(failedChecks) == 0
 
 
-def convert_to_usd(gltf_file, usd_file, fps, scale, arkit=False, verbose=False, use_euler_rotation=False, optimize_textures=False, generate_texture_transform_texture=True):
+def convert_to_usd(gltf_file, usd_file, fps, scale, arkit=False, verbose=False, use_euler_rotation=False, optimize_textures=False, generate_texture_transform_texture=True, scale_texture=False):
     """Converts a glTF file to USD
 
     Arguments:
@@ -799,45 +824,65 @@ def convert_to_usd(gltf_file, usd_file, fps, scale, arkit=False, verbose=False, 
     Keyword Arguments:
         verbose {bool} -- [description] (default: {False})
     """
+    temp_dir = tempfile.mkdtemp()
+    temp_usd_file = os.path.join(temp_dir, ntpath.basename(usd_file))
+    try:
+        usd = GLTF2USD(gltf_file=gltf_file, usd_file=temp_usd_file, fps=fps, scale=scale, verbose=verbose, use_euler_rotation=use_euler_rotation, optimize_textures=optimize_textures, generate_texture_transform_texture=generate_texture_transform_texture, scale_texture=scale_texture)
+        if usd.stage:
+            asset = usd.stage.GetRootLayer()
+            usd.logger.info('Conversion complete!')
 
-    usd = GLTF2USD(gltf_file=gltf_file, usd_file=usd_file, fps=fps, scale=scale, verbose=verbose, use_euler_rotation=use_euler_rotation, optimize_textures=optimize_textures, generate_texture_transform_texture=generate_texture_transform_texture)
-    if usd.stage:
-        asset = usd.stage.GetRootLayer()
-        usd.logger.info('Conversion complete!')
+            asset.Save()
+            usd.logger.info('created {}'.format(asset.realPath))
+            if not os.path.isdir(os.path.dirname(usd_file)):
+                os.makedirs(os.path.dirname(usd_file))
 
-        asset.Save()
-        usd.logger.info('created {}'.format(asset.realPath))
+            if temp_usd_file.endswith('.usdz') or temp_usd_file.endswith('.usdc'):
+                usdc_file = '%s.%s' % (os.path.splitext(temp_usd_file)[0], 'usdc')
+                asset.Export(usdc_file, args=dict(format='usdc'))
+                usd.logger.info('created {}'.format(usdc_file))
 
-        if usd_file.endswith('.usdz') or usd_file.endswith('.usdc'):
-            usdc_file = '%s.%s' % (os.path.splitext(usd_file)[0], 'usdc')
-            asset.Export(usdc_file, args=dict(format='usdc'))
-            usd.logger.info('created {}'.format(usdc_file))
+            if temp_usd_file.endswith('.usdz'):
+                #change to directory of the generated usd files to avoid issues with 
+                # relative paths with CreateNewUsdzPackage
+                os.chdir(os.path.dirname(usdc_file))
+                temp_usd_file = ntpath.basename(temp_usd_file)
+                r = Ar.GetResolver()
+                resolved_asset = r.Resolve(ntpath.basename(usdc_file))
+                context = r.CreateDefaultContextForAsset(resolved_asset)
 
-        if usd_file.endswith('.usdz'):
-            #change to directory of the generated usd files to avoid issues with 
-            # relative paths with CreateNewUsdzPackage
-            os.chdir(os.path.dirname(usdc_file))
-            usd_file = ntpath.basename(usd_file)
-            r = Ar.GetResolver()
-            resolved_asset = r.Resolve(ntpath.basename(usdc_file))
-            context = r.CreateDefaultContextForAsset(resolved_asset)
+                success = check_usd_compliance(resolved_asset, arkit=args.arkit)
+                with Ar.ResolverContextBinder(context):
+                    if arkit and not success:
+                        usd.logger.warning('USD is not ARKit compliant')
+                        return
 
-            success = check_usd_compliance(resolved_asset, arkit=args.arkit)
-            with Ar.ResolverContextBinder(context):
-                if arkit and not success:
-                    usd.logger.warning('USD is not ARKit compliant')
-                    return
+                    success = UsdUtils.CreateNewUsdzPackage(resolved_asset, temp_usd_file) and success
+                    if success:
+                        shutil.copyfile(temp_usd_file, usd_file)
+                        usd.logger.info('created package {} with contents:'.format(usd_file))
+                        zip_file = Usd.ZipFile.Open(usd_file)
+                        file_names = zip_file.GetFileNames()
+                        for file_name in file_names:
+                            usd.logger.info('\t{}'.format(file_name))
+                    else:
+                        usd.logger.error('could not create {}'.format(usd_file))
+            else:
+                # Copy textures referenced in the Usda/Usdc files from the temp directory to the target directory
+                temp_stage = Usd.Stage.Open(temp_usd_file)
+                usd_uv_textures = [x for x in temp_stage.Traverse() if x.IsA(UsdShade.Shader) and UsdShade.Shader(x).GetShaderId() == 'UsdUVTexture']
 
-                success = UsdUtils.CreateNewUsdzPackage(resolved_asset, usd_file) and success
-                if success:
-                    usd.logger.info('created package {} with contents:'.format(usd_file))
-                    zip_file = Usd.ZipFile.Open(usd_file)
-                    file_names = zip_file.GetFileNames()
-                    for file_name in file_names:
-                        usd.logger.info('\t{}'.format(file_name))
-                else:
-                    usd.logger.error('could not create {}'.format(usd_file))
+                for usd_uv_texture in usd_uv_textures:
+                    file_name = usd_uv_texture.GetAttribute('inputs:file').Get()
+                    if file_name:
+                        file_name = str(file_name).replace('@', '')
 
+                        if os.path.isfile(os.path.join(temp_dir, file_name)):
+                            shutil.copyfile(os.path.join(temp_dir, file_name), os.path.join(os.path.dirname(usd_file), file_name))
+                shutil.copyfile(temp_usd_file, usd_file)
+    finally:
+        shutil.rmtree(temp_dir)
+            
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Convert glTF to USD: v{}'.format(__version__))
@@ -851,9 +896,10 @@ if __name__ == '__main__':
     parser.add_argument('--optimize-textures', action='store_true', dest='optimize_textures', default=False, help='Specifies if image file size should be optimized and reduced at the expense of longer export time')
     parser.add_argument('--generate_texture_transform_texture', dest='generate_texture_transform_texture', action='store_true', help='Enables texture transform texture generation')
     parser.add_argument('--no-generate_texture_transform_texture', dest='generate_texture_transform_texture', action='store_false', help='Disables texture transform texture generation')
+    parser.add_argument('--scale-texture', dest='scale_texture', action='store_true', help='Multiplies metallic/roughness factors by textures', default=False)
     parser.set_defaults(generate_texture_transform_texture=True)
 
     args = parser.parse_args()
 
     if args.gltf_file:
-        convert_to_usd(os.path.expanduser(args.gltf_file), os.path.abspath(os.path.expanduser(args.usd_file)), args.fps, args.scale, args.arkit, args.verbose, args.use_euler_rotation, args.optimize_textures, args.generate_texture_transform_texture)
+        convert_to_usd(os.path.expanduser(args.gltf_file), os.path.abspath(os.path.expanduser(args.usd_file)), args.fps, args.scale, args.arkit, args.verbose, args.use_euler_rotation, args.optimize_textures, args.generate_texture_transform_texture, args.scale_texture)


### PR DESCRIPTION
## 0.2.0 (2019-02-27)
**Fixed Bugs:**
- Fix blend shapes
**Changes:**
- The Usd file generation now happens in a temp directory
- Add `--scale-texture` optional parameter to multiply metallic/roughness factors by textures
- Added creator metadata
- Moved material scope to below root xform
- connect opacity of diffuse texture if alpha blend or mask is used
- Export extras data on nodes and glTF asset 