### PR TITLE
Update README to include hint on USD.command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This tool currently only works on glTF 2.0 files, based on the core glTF 2.0 spe
 - You will need to initially have [USD v18.09 or v18.11](https://github.com/PixarAnimationStudios/USD) installed on your system
 and have the Python modules built
     - Linux users will need to build the tools themselves, or use [AnimalLogic's USD Docker Container](https://github.com/AnimalLogic/docker-usd) (recommended for non-CentOS users)
-    - macOS users can use Apple's [Prebuilt USD Toolkit](https://developer.apple.com/go/?id=python-usd-library). Make sure you add the USD dir to your `PYTHONPATH`
+    - macOS users can use Apple's [Prebuilt USD Toolkit](https://developer.apple.com/go/?id=python-usd-library). Make sure you add the USD dir to your `PYTHONPATH` (an easy way to do this is to run the `path_to_usdpython/USD.command` shell command included with the prebuilt USD Toolkit).
 
 ### Python dependencies
 You can install the following python dependencies using `pip install -r requirements.txt`:


### PR DESCRIPTION
The README included with Apple's prebuilt USD Toolkit seems to specify incorrect paths to have python load the appropriate modules correctly. There is an included USD.command script included with their toolkit though that I thought would be helpful for other developers to know about after I had trouble trying to manually configure the correct paths.