### PR TITLE
Fix animation linear interpolation

### DIFF
--- a/Source/_gltf2usd/gltf2/Animation.py
+++ b/Source/_gltf2usd/gltf2/Animation.py
@@ -92,9 +92,9 @@ class AnimationSampler(object):
             one_minus_factor = 1 - factor
             #translation or scale interpolation
             return [
-                (factor * value0[0] + (one_minus_factor * value1[0])), 
-                (factor * value0[1] + (one_minus_factor * value1[1])), 
-                (factor * value0[2] + (one_minus_factor * value1[2]))
+                (factor * value1[0] + (one_minus_factor * value0[0])),
+                (factor * value1[1] + (one_minus_factor * value0[1])),
+                (factor * value1[2] + (one_minus_factor * value0[2]))
             ]
 
         elif len(value0) == 4:


### PR DESCRIPTION
This is a small fix for the linear interpolation of vectors in the Animation class.
The previous implementation was sampling values from end to start, rather than start to end.

Following is the correct method:
```
float lerp(float v0, float v1, float t) {
  return (1 - t) * v0 + t * v1;
}
```